### PR TITLE
Sets console cursor to white

### DIFF
--- a/Amoyly.dvtcolortheme
+++ b/Amoyly.dvtcolortheme
@@ -25,7 +25,7 @@
 	<key>DVTConsoleTextBackgroundColor</key>
 	<string>0.153787 0.157608 0.132408 1</string>
 	<key>DVTConsoleTextInsertionPointColor</key>
-	<string>0 0 0 1</string>
+	<string>1 1 1 1</string>
 	<key>DVTConsoleTextSelectionColor</key>
 	<string>0.576266 0.81005 1 1</string>
 	<key>DVTDebuggerInstructionPointerColor</key>


### PR DESCRIPTION
Thanks so much for this great theme, it is my go-to Xcode color scheme!

This PR sets the cursor's color to white in the console, so it is visible for interacting with lldb
